### PR TITLE
Execute deployed cairo assembly programs instead of hardcoded ones

### DIFF
--- a/pallets/cairo/src/compilation/mock.rs
+++ b/pallets/cairo/src/compilation/mock.rs
@@ -16,8 +16,9 @@ impl<T: Config> SierraCompiler<T> for SierraCompilerMock {
 	) -> Result<CairoAssemblyProgram<T>, Error<T>> {
 		Ok(CairoAssemblyProgram {
 			// TODO: Think if we should generate id during compilation or not.
-			id: None,
-			sierra_program_id: sierra_program.id,
+			// For mock it is ok to use the same id as the sierra program.
+			id: sierra_program.id.clone(),
+			sierra_program_id: Some(sierra_program.id),
 			code: BoundedVec::with_bounded_capacity(0),
 		})
 	}

--- a/pallets/cairo/src/execution/cairo_vm_executor.rs
+++ b/pallets/cairo/src/execution/cairo_vm_executor.rs
@@ -17,10 +17,14 @@ use crate::{
 lazy_static! {
 	/// The Cairo VM executor.
 	pub static ref CAIRO_VM_EXECUTOR: CairoVmExecutor = CairoVmExecutor::default();
+	/// The Cairo run configuration.
+	pub static ref CAIRO_RUN_CONFIG: CairoRunConfig<'static> = CairoRunConfig::default();
 	/// The Fibonacci Cairo program, hardcoded in JSON format.
 	static ref FIBONACCI_PROGRAM: Program = Program::from_bytes(include_bytes!("./samples/fib.json"), Some("main")).unwrap();
 	static ref ADD_PROGRAM: Program = Program::from_bytes(include_bytes!("./samples/add.json"), Some("main")).unwrap();
 }
+
+const ENTRY_POINT_MAIN: Option<&str> = Some("main");
 
 /// Cairo VM executor.
 #[derive(Default)]
@@ -36,20 +40,35 @@ impl<T: Config> CairoExecutor<T> for CairoVmExecutor {
 	/// # Returns
 	/// The result of executing the Cairo program.
 	/// # TODO
-	/// * Replace the hardcoded Cairo program with the actual Cairo program.
 	/// * Replace the hardcoded input with the actual input.
 	/// * Proper error handling (remove `unwrap()` calls).
 	fn execute(
 		&self,
-		_cairo_program: &CairoAssemblyProgram<T>,
+		cairo_program: &CairoAssemblyProgram<T>,
 		_input: &CairoAssemblyProgramInput,
 	) -> Result<CairoAssemblyProgramOutput, Error<T>> {
-		CairoVmExecutor::run_program(&FIBONACCI_PROGRAM).unwrap();
+		// Instantiate the Cairo program.
+		let program = Program::from_bytes(&cairo_program.code, ENTRY_POINT_MAIN).unwrap();
+		// Run the Cairo program.
+		CairoVmExecutor::run_program(&program).unwrap();
+		// TODO: retrieve the output from the execution of the Cairo program.
 		Ok(CairoAssemblyProgramOutput::empty())
 	}
 }
 
 impl CairoVmExecutor {
+	/// Runs the program with the given id.
+	///
+	/// This function is used for testing purposes. It is not used in the production version of the
+	/// app.
+	///
+	/// # Arguments
+	///
+	/// * `id` - The id of the program to run.
+	///
+	/// # Notes
+	///
+	/// This function is only used for testing purposes. It is not used in production.
 	pub fn run_hardcoded_program(id: u8) {
 		match id {
 			0 => {
@@ -64,15 +83,25 @@ impl CairoVmExecutor {
 		};
 	}
 
+	/// Runs a Cairo program in the Cairo VM
+	///
+	/// # Arguments
+	/// * `program` - the Cairo program to run
+	///
+	/// # Returns
+	/// * `Result<(), ()>` - the result of running the Cairo program
+	///
+	/// # Errors
+	/// * `()` - if the Cairo program fails to run
 	fn run_program(program: &Program) -> Result<(), ()> {
 		log::info!("starting execution of Cairo program in Cairo VM");
 
-		let cairo_run_config = CairoRunConfig::default();
 		let mut hint_executor = BuiltinHintProcessor::new_empty();
 		let mut cairo_runner =
-			CairoRunner::new(program, cairo_run_config.layout, cairo_run_config.proof_mode)
+			CairoRunner::new(program, CAIRO_RUN_CONFIG.layout, CAIRO_RUN_CONFIG.proof_mode)
 				.unwrap();
-		let mut vm = VirtualMachine::new(cairo_run_config.trace_enabled);
+		let mut vm = VirtualMachine::new(CAIRO_RUN_CONFIG.trace_enabled);
+
 		let end = cairo_runner.initialize(&mut vm).unwrap();
 		cairo_runner
 			.run_until_pc(end, &mut vm, &mut hint_executor)

--- a/pallets/cairo/src/execution/samples/add.json
+++ b/pallets/cairo/src/execution/samples/add.json
@@ -1,0 +1,279 @@
+{
+    "attributes": [],
+    "builtins": [],
+    "compiler_version": "0.10.3",
+    "data": [
+        "0x482a7ffd7ffc8000",
+        "0x208b7fff7fff7ffe",
+        "0x480680017fff8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0x2",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.add.a": 0,
+                        "__main__.add.b": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 17,
+                    "end_line": 2,
+                    "input_file": {
+                        "filename": "core/tests/test_data/cairo/add0.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 2
+                }
+            },
+            "1": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.add"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.add.a": 0,
+                        "__main__.add.b": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 2,
+                    "input_file": {
+                        "filename": "core/tests/test_data/cairo/add0.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 2
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 10,
+                    "end_line": 5,
+                    "input_file": {
+                        "filename": "core/tests/test_data/cairo/add0.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 5
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 5,
+                    "input_file": {
+                        "filename": "core/tests/test_data/cairo/add0.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 5
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 2
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 5,
+                    "input_file": {
+                        "filename": "core/tests/test_data/cairo/add0.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 5
+                }
+            },
+            "8": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 5
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 6,
+                    "input_file": {
+                        "filename": "core/tests/test_data/cairo/add0.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 6
+                }
+            }
+        }
+    },
+    "hints": {},
+    "identifiers": {
+        "__main__.add": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "__main__.add.Args": {
+            "full_name": "__main__.add.Args",
+            "members": {
+                "a": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "b": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.add.ImplicitArgs": {
+            "full_name": "__main__.add.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.add.Return": {
+            "cairo_type": "felt",
+            "type": "type_definition"
+        },
+        "__main__.add.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.add.a": {
+            "cairo_type": "felt",
+            "full_name": "__main__.add.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.add.b": {
+            "cairo_type": "felt",
+            "full_name": "__main__.add.b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 2,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-3), felt*)]"
+            }
+        ]
+    }
+}

--- a/pallets/cairo/src/lib.rs
+++ b/pallets/cairo/src/lib.rs
@@ -40,7 +40,6 @@ pub mod pallet {
 			cairo_vm_executor::{CairoVmExecutor, CAIRO_VM_EXECUTOR},
 			CairoExecutor,
 		},
-		hash,
 		types::{
 			CairoAssemblyProgamId, CairoAssemblyProgram, CairoAssemblyProgramInput,
 			CairoAssemblyProgramOutput, SierraProgram, SierraProgramId,
@@ -100,6 +99,8 @@ pub mod pallet {
 			sierra_program_id: SierraProgramId,
 			cairo_assembly_program_id: CairoAssemblyProgamId,
 		},
+		/// A new Cairo assembly program has been successfully deployed.
+		CairoAssemblyProgramDeployed { id: CairoAssemblyProgamId, deployer_account: T::AccountId },
 		/// A Cairo assembly program has been successfully executed.
 		CairoAssemblyProgramExecuted {
 			cairo_assembly_program_id: CairoAssemblyProgamId,
@@ -118,6 +119,8 @@ pub mod pallet {
 		SierraProgramNotFound,
 		/// The Cairo assembly program does not exist.
 		CairoAssemblyProgramNotFound,
+		/// The Cairo assembly program already exists.
+		CairoAssemblyProgramAlreadyExists,
 	}
 
 	/// The Cairo Execution Engine pallet external functions.
@@ -149,13 +152,36 @@ pub mod pallet {
 			Ok(())
 		}
 
+		/// Deploy a new Cairo assembly program.
+		/// # Arguments
+		/// - `origin`: The origin of the call
+		/// - `cairo_assembly_program`: The Cairo assembly code of the program to deploy.
+		/// # TODO
+		/// - do benchmarking to determine the appropriate `weight` for this call.
+		#[pallet::call_index(1)]
+		#[pallet::weight(0)]
+		pub fn deploy_cairo_assembly_program(
+			origin: OriginFor<T>,
+			cairo_assembly_program: BoundedVec<u8, T::MaxCairoAssemblyProgramLength>,
+		) -> DispatchResult {
+			// Make sure the caller is from a signed origin and retrieve the signer.
+			let deployer_account = ensure_signed(origin)?;
+
+			log::info!("Deploying Cairo assembly program from account: {:?}", deployer_account);
+
+			// Call internal function to do the actual deployment.
+			Self::do_deploy_cairo_assembly_program(&deployer_account, cairo_assembly_program)?;
+
+			Ok(())
+		}
+
 		/// Compile a Sierra program into a Cairo assembly program and store it in storage.
 		/// # Arguments
 		/// - `origin`: The origin of the call
 		/// - `sierra_program_id`: The id of the Sierra program to compile.
 		/// # TODO
 		/// - do benchmarking to determine the appropriate `weight` for this call.
-		#[pallet::call_index(1)]
+		#[pallet::call_index(2)]
 		#[pallet::weight(0)]
 		pub fn compile_sierra_program(
 			origin: OriginFor<T>,
@@ -177,7 +203,7 @@ pub mod pallet {
 		/// - do benchmarking to determine the appropriate `weight` for this call.
 		/// - implement the actual execution of the Cairo assembly program.
 		/// - implement the return value of the execution.
-		#[pallet::call_index(2)]
+		#[pallet::call_index(3)]
 		#[pallet::weight(0)]
 		pub fn execute_cairo_assembly_program(
 			origin: OriginFor<T>,
@@ -199,7 +225,7 @@ pub mod pallet {
 		/// # Arguments
 		/// - `origin`: The origin of the call
 		/// - `program_id`: The id of the Cairo assembly program to execute.
-		#[pallet::call_index(3)]
+		#[pallet::call_index(4)]
 		#[pallet::weight(0)]
 		pub fn execute_hardcoded_cairo_assembly_program(
 			origin: OriginFor<T>,
@@ -252,28 +278,55 @@ pub mod pallet {
 			Ok(sierra_program_id)
 		}
 
+		/// Deploy a new Cairo assembly program.
+		/// # Arguments
+		/// - `deployer_account`: The account identifier of the deployer.
+		/// - `cairo_assembly_program`: The Cairo assembly program to deploy.
+		fn do_deploy_cairo_assembly_program(
+			deployer_account: &T::AccountId,
+			cairo_assembly_program: BoundedVec<u8, T::MaxCairoAssemblyProgramLength>,
+		) -> Result<SierraProgramId, DispatchError> {
+			// Generate Cairo assembly program id.
+			let cairo_assembly_program_id =
+				Self::gen_cairo_assembly_program_id(&cairo_assembly_program)?;
+
+			// Check if the Cairo assembly program already exists in storage.
+			ensure!(
+				!CairoAssemblyPrograms::<T>::contains_key(cairo_assembly_program_id),
+				Error::<T>::CairoAssemblyProgramAlreadyExists
+			);
+
+			// Validate the Cairo assembly program
+			Self::validate_cairo_assembly_program(&cairo_assembly_program)?;
+
+			// Create the Cairo assembly program instance.
+			let cairo_assembly_program = CairoAssemblyProgram::<T> {
+				id: cairo_assembly_program_id,
+				code: cairo_assembly_program,
+				sierra_program_id: None,
+			};
+
+			// Insert the Cairo assembly program in storage.
+			CairoAssemblyPrograms::<T>::insert(cairo_assembly_program_id, &cairo_assembly_program);
+
+			// Emit events.
+			Self::deposit_event(Event::CairoAssemblyProgramDeployed {
+				id: cairo_assembly_program_id,
+				deployer_account: deployer_account.clone(),
+			});
+
+			Ok(cairo_assembly_program_id)
+		}
+
 		/// Compute the id of a Sierra program from it's code.
 		/// TODO: move to hash of the code
 		pub fn gen_sierra_program_id(
 			_deployer_account: &T::AccountId,
-			_sierra_code: &BoundedVec<u8, T::MaxSierraProgramLength>,
+			sierra_code: &BoundedVec<u8, T::MaxSierraProgramLength>,
 		) -> Result<SierraProgramId, DispatchError> {
-			// Create some randomness.
-			let random = T::Randomness::random(&b"sierra"[..]).0;
-
-			// Add some uniqueness because multiple ids can generated in the same block.
-			let unique_payload = (
-				random,
-				frame_system::Pallet::<T>::extrinsic_index().unwrap_or_default(),
-				frame_system::Pallet::<T>::block_number(),
-			);
-
-			// Turns into a byte array.
-			let encoded_payload = unique_payload.encode();
 			// Compute the hash and return as id.
 			// TODO: use poseidon hash when it is available.
-			let _hash = hash::poseidon(&encoded_payload);
-			Ok(frame_support::Hashable::blake2_256(&encoded_payload))
+			Ok(frame_support::Hashable::blake2_256(&sierra_code.encode()))
 		}
 
 		/// Validate the Sierra program code.
@@ -284,6 +337,19 @@ pub mod pallet {
 			// Check that the program is not too big.
 			ensure!(
 				sierra_code.len() <= T::MaxSierraProgramLength::get() as usize,
+				Error::<T>::ProgramTooBig
+			);
+			Ok(())
+		}
+
+		/// Validate the Cairo assembly program.
+		/// TODO: implement proper validation.
+		pub fn validate_cairo_assembly_program(
+			cairo_assembly_program: &BoundedVec<u8, T::MaxCairoAssemblyProgramLength>,
+		) -> Result<(), DispatchError> {
+			// Check that the program is not too big.
+			ensure!(
+				cairo_assembly_program.len() <= T::MaxCairoAssemblyProgramLength::get() as usize,
 				Error::<T>::ProgramTooBig
 			);
 			Ok(())
@@ -307,26 +373,22 @@ pub mod pallet {
 			// Create an instance of the Cairo compiler.
 			let compiler = SierraCompilerMock::default();
 			// Compile the Sierra program into a Cairo assembly program.
-			let mut cairo_assembly_program = compiler.compile(&sierra_program)?;
-			// Generate a unique id for the Cairo assembly program.
-			let cairo_assembly_program_id =
-				Self::gen_cairo_assembly_program_id(&cairo_assembly_program.code)?;
-			// Set the id of the Cairo assembly program.
-			cairo_assembly_program.id = Some(cairo_assembly_program_id);
+			let cairo_assembly_program = compiler.compile(&sierra_program)?;
+
 			// Store the Cairo assembly program in storage.
-			CairoAssemblyPrograms::<T>::insert(cairo_assembly_program_id, &cairo_assembly_program);
+			CairoAssemblyPrograms::<T>::insert(cairo_assembly_program.id, &cairo_assembly_program);
 			// Update the Sierra program with the id of the Cairo assembly program.
-			sierra_program.cairo_assembly_program_id = Some(cairo_assembly_program_id);
+			sierra_program.cairo_assembly_program_id = Some(cairo_assembly_program.id);
 			// Update the Sierra program in storage.
 			SierraPrograms::<T>::insert(sierra_program_id, &sierra_program);
 
 			// Emit events.
 			Self::deposit_event(Event::CairoAssemblyProgramCompiled {
 				sierra_program_id,
-				cairo_assembly_program_id,
+				cairo_assembly_program_id: cairo_assembly_program.id,
 			});
 			// Return the id of the Cairo assembly program.
-			Ok(cairo_assembly_program_id)
+			Ok(cairo_assembly_program.id)
 		}
 
 		/// Execute a Cairo assembly program.
@@ -346,8 +408,6 @@ pub mod pallet {
 			// Retrieve the Cairo assembly program from storage.
 			let cairo_assembly_program = CairoAssemblyPrograms::<T>::get(cairo_assembly_program_id)
 				.ok_or(Error::<T>::CairoAssemblyProgramNotFound)?;
-			// Create an instance of the Cairo executor.
-			//let cairo_executor = CairoVmExecutor::default();
 			// Execute the Cairo assembly program.
 			let output = CAIRO_VM_EXECUTOR.execute(&cairo_assembly_program, &input)?;
 
@@ -362,24 +422,11 @@ pub mod pallet {
 		/// Compute the id of a Sierra program from it's code.
 		/// TODO: move to hash of the code
 		pub fn gen_cairo_assembly_program_id(
-			_cairo_assembly_code: &BoundedVec<u8, T::MaxCairoAssemblyProgramLength>,
+			cairo_assembly_code: &BoundedVec<u8, T::MaxCairoAssemblyProgramLength>,
 		) -> Result<CairoAssemblyProgamId, DispatchError> {
-			// Create some randomness.
-			let random = T::Randomness::random(&b"casm"[..]).0;
-
-			// Add some uniqueness because multiple ids can generated in the same block.
-			let unique_payload = (
-				random,
-				frame_system::Pallet::<T>::extrinsic_index().unwrap_or_default(),
-				frame_system::Pallet::<T>::block_number(),
-			);
-
-			// Turns into a byte array.
-			let encoded_payload = unique_payload.encode();
 			// Compute the hash and return as id.
 			// TODO: use poseidon hash when it is available.
-			let _hash = hash::poseidon(&encoded_payload);
-			Ok(frame_support::Hashable::blake2_256(&encoded_payload))
+			Ok(frame_support::Hashable::blake2_256(&cairo_assembly_code.encode()))
 		}
 
 		/// Execute a hardcoded Cairo assembly program. (testing purposes only)

--- a/pallets/cairo/src/lib.rs
+++ b/pallets/cairo/src/lib.rs
@@ -194,6 +194,23 @@ pub mod pallet {
 			)?;
 			Ok(())
 		}
+
+		/// Execute a hardcoded Cairo assembly program. (testing purposes only)
+		/// # Arguments
+		/// - `origin`: The origin of the call
+		/// - `program_id`: The id of the Cairo assembly program to execute.
+		#[pallet::call_index(3)]
+		#[pallet::weight(0)]
+		pub fn execute_hardcoded_cairo_assembly_program(
+			origin: OriginFor<T>,
+			program_id: u8,
+		) -> DispatchResult {
+			// Make sure the caller is from a signed origin and retrieve the signer.
+			let caller_account = ensure_signed(origin)?;
+			// Call internal function to do the actual execution.
+			Self::do_execute_hardcoded_cairo_assembly_program(&caller_account, program_id)?;
+			Ok(())
+		}
 	}
 
 	/// The Cairo Execution Engine pallet internal functions.
@@ -363,6 +380,18 @@ pub mod pallet {
 			// TODO: use poseidon hash when it is available.
 			let _hash = hash::poseidon(&encoded_payload);
 			Ok(frame_support::Hashable::blake2_256(&encoded_payload))
+		}
+
+		/// Execute a hardcoded Cairo assembly program. (testing purposes only)
+		/// # Arguments
+		/// - `caller_account`: The account identifier of the caller.
+		/// - `program_id`: The id of the Cairo assembly program to execute.
+		pub fn do_execute_hardcoded_cairo_assembly_program(
+			_caller_account: &T::AccountId,
+			program_id: u8,
+		) -> Result<(), DispatchError> {
+			CairoVmExecutor::run_hardcoded_program(program_id);
+			Ok(())
 		}
 	}
 }

--- a/pallets/cairo/src/types.rs
+++ b/pallets/cairo/src/types.rs
@@ -44,9 +44,10 @@ pub struct CairoAssemblyProgram<T: Config> {
 	/// from the generation of the Cairo assembly program identifier.
 	/// If at some point that it does not make sense, we can remove the `Option` and make this
 	/// field mandatory.
-	pub id: Option<CairoAssemblyProgamId>,
+	pub id: CairoAssemblyProgamId,
 	/// The identifier of the Sierra program that was compiled to the Cairo assembly program.
-	pub sierra_program_id: SierraProgramId,
+	/// None if the Cairo assembly program was not compiled from a Sierra program.
+	pub sierra_program_id: Option<SierraProgramId>,
 	/// The code of the Cairo assembly program.
 	pub code: BoundedVec<u8, T::MaxCairoAssemblyProgramLength>,
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently only hardcoded program is run when call execute cairo assembly extrinsic.
Issue Number: fixes #15


# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
It is now possible to run deployed cairo assembly programs.
# Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
