### PR TITLE
add nextest to CI workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           profile: minimal
           target: wasm32-unknown-unknown
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@nextest
       - name: Set-Up
         run: >
           sudo apt-get update && sudo apt-get install -y
@@ -35,7 +37,7 @@ jobs:
       - name: Check Build and run tests
         run: |
           SKIP_WASM_BUILD=1 cargo check --release
-          cargo test --all
+          cargo nextest run
 
   bench:
     # The type of runner that the job will run on


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [x] Testing
- [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #67 
# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adding `nextest` to the CI workflow
- Replacing the call of `cargo test` with `cargo nextest run`

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

It seems there's an improvement of about 2s when running tests with `cargo nextest run` instead of running `cargo test`

`cargo test  3.17s user 1.49s system 78% cpu 5.915 total`
`cargo nextest run  1.20s user 0.65s system 91% cpu 2.021 total`


CI output now shows the following:
![image](https://user-images.githubusercontent.com/2940022/226429273-39491f3c-09ef-4034-ada2-4729e7fdfc79.png)

